### PR TITLE
Add wildcard for generating api docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ $ py.test-3 tests/ --pep8 biotaphy -v --cov biotaphy --cov-report term-missing
 * If you update in-line documentation, make sure to rebuild the API doc RST files
 
 ```
-$ sphinx-apidoc -o ./_sphinx_config/source ./biotaphy/
+$ sphinx-apidoc -o ./_sphinx_config/source ./biotaphy/*
 ```
 
 * If you edit any RST docs (or update API docs), rebuild the html pages


### PR DESCRIPTION
This will catch submodules

## Pull Request Type
 - [ ] Bug Fix
 - [ ] New Feature
 - [X] Documentation
 - [ ] Other
 
## Status
 - [X] Ready
 - [ ] In development
 - [ ] Hold

## Description
Add wildcard to generate full API docs

