### PR TITLE
63 create accepted name data wranglers using otol name resolution

### DIFF
--- a/biotaphy/data_wrangling/__init__.py
+++ b/biotaphy/data_wrangling/__init__.py
@@ -1,0 +1,1 @@
+"""Data wrangling module __init__ file."""

--- a/biotaphy/data_wrangling/matrix/__init__.py
+++ b/biotaphy/data_wrangling/matrix/__init__.py
@@ -1,0 +1,1 @@
+"""Matrix data wrangling module __init__.py file."""

--- a/biotaphy/data_wrangling/matrix/accepted_name_data_wrangler.py
+++ b/biotaphy/data_wrangling/matrix/accepted_name_data_wrangler.py
@@ -1,0 +1,53 @@
+"""Module containing accepted name wrangler for a matrix using Open Tree of Life."""
+from lmpy.data_wrangling.matrix.accepted_name_wrangler import (
+    AcceptedNameMatrixWrangler
+)
+
+from biotaphy.client.ot_service_wrapper.open_tree import resolve_names_otol
+
+
+# .....................................................................................
+class BiotaphyAcceptedNameMatrixWrangler(AcceptedNameMatrixWrangler):
+    """Modifies matrix columns to update taxon names to the "accepted" names."""
+    name = 'BiotaphyAcceptedNameMatrixWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        name_map=None,
+        name_resolver=None,
+        taxon_axis=1,
+        purge_failures=True,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
+        **params
+    ):
+        """Constructor for AcceptedNameMatrixModifier class.
+
+        Args:
+            name_map (dict): A map of original name to accepted name.
+            name_resolver (str or Method): If provided, use this method for getting new
+                accepted names.  If set to 'gbif', use GBIF name resolution.
+            taxon_axis (int): The axis with taxon headers.
+            purge_failures (bool): Should failures be purged from the matrix.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
+            **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
+        """
+        if isinstance(name_resolver, str) and name_resolver.lower() == 'otol':
+            name_resolver = resolve_names_otol
+        AcceptedNameMatrixWrangler.__init__(
+            self,
+            name_map=name_map,
+            name_resolver=name_resolver,
+            taxon_axis=taxon_axis,
+            purge_failures=purge_failures,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
+            **params,
+        )

--- a/biotaphy/data_wrangling/occurrence/__init__.py
+++ b/biotaphy/data_wrangling/occurrence/__init__.py
@@ -1,0 +1,1 @@
+"""Occurrence data wrangling module __init__ file."""

--- a/biotaphy/data_wrangling/occurrence/accepted_name_data_wrangler.py
+++ b/biotaphy/data_wrangling/occurrence/accepted_name_data_wrangler.py
@@ -1,0 +1,51 @@
+"""Accepted name data wrangler for occurrences using OTOL name resolution."""
+from lmpy.data_wrangling.occurrence.accepted_name_wrangler import (
+    AcceptedNameOccurrenceWrangler,
+)
+
+from biotaphy.client.ot_service_wrapper.open_tree import resolve_names_otol
+
+
+# .....................................................................................
+class BiotaphyAcceptedNameOccurrenceWrangler(AcceptedNameOccurrenceWrangler):
+    """Modifies the species_name to the "accepted" taxon name for the species."""
+    name = 'BiotaphyAcceptedNameOccurrenceWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        name_map=None,
+        name_resolver=None,
+        store_original_attribute=None,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
+        **params
+    ):
+        """Constructor for BiotaphyAcceptedNameOccurrenceWrangler.
+
+        Args:
+            name_map (dict or str): A map of original name to accepted name.
+            name_resolver (str or Method): If provided, use this method for getting new
+                accepted names.  If set to 'gbif', use GBIF name resolution.
+            store_original_attribute (str or None): A new attribute to store the
+                original taxon name.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
+            **params (dict): Keyword parameters to pass to _OccurrenceDataWrangler.
+        """
+        if isinstance(name_resolver, str) and name_resolver.lower() == 'otol':
+            name_resolver = resolve_names_otol
+        AcceptedNameOccurrenceWrangler.__init__(
+            self,
+            name_map=name_map,
+            name_resolver=name_resolver,
+            store_original_attribute=store_original_attribute,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
+            **params
+        )

--- a/biotaphy/data_wrangling/species_list/__init__.py
+++ b/biotaphy/data_wrangling/species_list/__init__.py
@@ -1,0 +1,1 @@
+"""Species list data wrangling module __init__ file."""

--- a/biotaphy/data_wrangling/species_list/accepted_name_data_wrangler.py
+++ b/biotaphy/data_wrangling/species_list/accepted_name_data_wrangler.py
@@ -1,0 +1,50 @@
+"""Accepted name wrangler for species list using OTOL names."""
+from lmpy.data_wrangling.species_list.accepted_name_wrangler import (
+    AcceptedNameSpeciesListWrangler
+)
+
+from biotaphy.client.ot_service_wrapper.open_tree import resolve_names_otol
+
+
+# .....................................................................................
+class BiotaphyAcceptedNameSpeciesListWrangler(AcceptedNameSpeciesListWrangler):
+    """Modifies a species list to update taxon names to the "accepted" names."""
+    name = 'BiotaphyAcceptedNameSpeciesListWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        name_map=None,
+        name_resolver=None,
+        purge_failures=True,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
+        **params
+    ):
+        """Constructor for BiotaphyAcceptedNameSpeciesListModifier class.
+
+        Args:
+            name_map (dict): A map of original name to accepted name.
+            name_resolver (str or Method): If provided, use this method for getting new
+                accepted names.  If set to 'gbif', use GBIF name resolution.
+            purge_failures (bool): Should failures be purged from the tree.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
+            **params (dict): Keyword parameters to pass to _TreeDataWrangler.
+        """
+        if isinstance(name_resolver, str) and name_resolver.lower() == 'otol':
+            name_resolver = resolve_names_otol
+        AcceptedNameSpeciesListWrangler.__init__(
+            self,
+            name_map=name_map,
+            name_resolver=name_resolver,
+            purge_failures=purge_failures,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
+            **params,
+        )

--- a/biotaphy/data_wrangling/tree/__init__.py
+++ b/biotaphy/data_wrangling/tree/__init__.py
@@ -1,0 +1,1 @@
+"""Tree data wrangling module __init__ file."""

--- a/biotaphy/data_wrangling/tree/accepted_name_data_wrangler.py
+++ b/biotaphy/data_wrangling/tree/accepted_name_data_wrangler.py
@@ -1,0 +1,50 @@
+"""Accepted name wrangler for trees using Open tree of Life for name resolution."""
+from lmpy.data_wrangling.tree.accepted_name_wrangler import (
+    AcceptedNameTreeWrangler
+)
+
+from biotaphy.client.ot_service_wrapper.open_tree import resolve_names_otol
+
+
+# .....................................................................................
+class BiotaphyAcceptedNameTreeWrangler(AcceptedNameTreeWrangler):
+    """Modifies tree columns to update taxon names to the "accepted" names."""
+    name = 'BiotaphyAcceptedNameTreeWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        name_map=None,
+        name_resolver=None,
+        purge_failures=True,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
+        **params
+    ):
+        """Constructor for BiotaphyAcceptedNameTreeModifier class.
+
+        Args:
+            name_map (dict): A map of original name to accepted name.
+            name_resolver (str or Method): If provided, use this method for getting new
+                accepted names.  If set to 'gbif', use GBIF name resolution.
+            purge_failures (bool): Should failures be purged from the tree.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
+            **params (dict): Keyword parameters to pass to _TreeDataWrangler.
+        """
+        if isinstance(name_resolver, str) and name_resolver.lower() == 'otol':
+            name_resolver = resolve_names_otol
+        AcceptedNameTreeWrangler.__init__(
+            self,
+            name_map=name_map,
+            name_resolver=name_resolver,
+            purge_failures=purge_failures,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
+            **params
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy>=1.11.0
 matplotlib
 rtree
 gdal
-specify-lmpy>=3.1.14
+specify-lmpy>=3.1.19

--- a/tests/test_data_wrangling/__init__.py
+++ b/tests/test_data_wrangling/__init__.py
@@ -1,0 +1,1 @@
+"""Module __init__ for data wrangling tests."""

--- a/tests/test_data_wrangling/test_data_wrangling_create.py
+++ b/tests/test_data_wrangling/test_data_wrangling_create.py
@@ -1,0 +1,78 @@
+"""Test class instantiation via WranglerFactory."""
+from lmpy.data_wrangling.factory import WranglerFactory
+
+from biotaphy.data_wrangling.matrix.accepted_name_data_wrangler import (
+    BiotaphyAcceptedNameMatrixWrangler
+)
+from biotaphy.data_wrangling.occurrence.accepted_name_data_wrangler import (
+    BiotaphyAcceptedNameOccurrenceWrangler
+)
+from biotaphy.data_wrangling.species_list.accepted_name_data_wrangler import (
+    BiotaphyAcceptedNameSpeciesListWrangler
+)
+from biotaphy.data_wrangling.tree.accepted_name_data_wrangler import (
+    BiotaphyAcceptedNameTreeWrangler
+)
+
+
+# .....................................................................................
+def test_factory_instantiation_matrix():
+    """Test that the Biotaphy matrix accepted name wrangler can be created."""
+    wrangler_configs = [
+        {
+            'module': 'biotaphy.data_wrangling.matrix.accepted_name_data_wrangler',
+            'wrangler_type': 'BiotaphyAcceptedNameMatrixWrangler',
+        }
+    ]
+    factory = WranglerFactory()
+    wranglers = factory.get_wranglers(wrangler_configs)
+    assert len(wranglers) == 1
+    assert isinstance(wranglers[0], BiotaphyAcceptedNameMatrixWrangler)
+
+
+# .....................................................................................
+def test_factory_instantiation_occurrence():
+    """Test that the Biotaphy occurrence accepted name wrangler can be created."""
+    wrangler_configs = [
+        {
+            'module': 'biotaphy.data_wrangling.occurrence.accepted_name_data_wrangler',
+            'wrangler_type': 'BiotaphyAcceptedNameOccurrenceWrangler',
+        }
+    ]
+    factory = WranglerFactory()
+    wranglers = factory.get_wranglers(wrangler_configs)
+    assert len(wranglers) == 1
+    assert isinstance(wranglers[0], BiotaphyAcceptedNameOccurrenceWrangler)
+
+
+# .....................................................................................
+def test_factory_instantiation_species_list():
+    """Test that the Biotaphy species list accepted name wrangler can be created."""
+    wrangler_configs = [
+        {
+            'module': (
+                'biotaphy.data_wrangling.species_list.'
+                'accepted_name_data_wrangler'
+            ),
+            'wrangler_type': 'BiotaphyAcceptedNameSpeciesListWrangler',
+        }
+    ]
+    factory = WranglerFactory()
+    wranglers = factory.get_wranglers(wrangler_configs)
+    assert len(wranglers) == 1
+    assert isinstance(wranglers[0], BiotaphyAcceptedNameSpeciesListWrangler)
+
+
+# .....................................................................................
+def test_factory_instantiation_tree():
+    """Test that the Biotaphy tree accepted name wrangler can be created."""
+    wrangler_configs = [
+        {
+            'module': 'biotaphy.data_wrangling.tree.accepted_name_data_wrangler',
+            'wrangler_type': 'BiotaphyAcceptedNameTreeWrangler',
+        }
+    ]
+    factory = WranglerFactory()
+    wranglers = factory.get_wranglers(wrangler_configs)
+    assert len(wranglers) == 1
+    assert isinstance(wranglers[0], BiotaphyAcceptedNameTreeWrangler)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Add data wranglers that use Open Tree of Life for name resolution.

## Link(s) to issue

#63 

## Dependencies added

Requires specify-lmpy>=3.1.19 for the updates to the data wrangler factory.